### PR TITLE
Docs: Fix instructions for setting up systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ EOF
 chmod 644 ~/.local/share/systemd/user/hyper-gateway.service
 
 systemctl --user daemon-reload
-systemctl --user enable hyper-gateway.service
 systemctl --user start hyper-gateway.service
 systemctl --user status hyper-gateway.service
 ```


### PR DESCRIPTION
systemctl --user enable hyper-gateway.service returns the error:

The unit files have no installation config (WantedBy=, RequiredBy=, Also=, Alias= settings in the [Install] section, and DefaultInstance= for template units). This means they are not meant to be enabled using systemctl.