### PR TITLE
Add debug to package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/RangerMauve/hyper-gateway#readme",
   "dependencies": {
+    "debug": "^4.3.4",
     "env-paths": "^2.2.1",
     "hyper-sdk": "^4.4.0",
     "hypercore-fetch": "^9.9.0",


### PR DESCRIPTION
Attempting to run `hyper-gateway` after `npm i -g hyper-gateway` complains `Cannot find package 'debug' ...`.